### PR TITLE
perl-5.26.0 compatibility

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 #-*- perl -*-
 
+use lib '.';
 use inc::Module::Install;
 
 # Define metadata


### PR DESCRIPTION
In Perl 5.26.0, '.' will no longer be found by default in @INC.  This patch
adjusts Makefile.PL to enable configuration in this case.

For:  https://rt.cpan.org/Ticket/Update.html?id=116459